### PR TITLE
disable coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,8 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
-
-matrix:
-  allow_failures:
-    - php: hhvm
 
 sudo: false
 
 before_script:
-  - composer require satooshi/php-coveralls:~1.0.0 --dev --no-progress --prefer-source
-
-script:
-  - mkdir -p build/logs
-  - phpunit --coverage-clover build/logs/clover.xml
-
-after_script:
-  - php vendor/bin/coveralls -v
+  - composer install --dev --prefer-source


### PR DESCRIPTION
Builds fail with 
```
  [Composer\Exception\NoSslException]                                          

  The openssl extension is required for SSL/TLS protection but is not availab  

  le. If you can not enable the openssl extension, you can disable this error  

  , at your own risk, by setting the 'disable-tls' option to true.             

                                                                               

The command "composer require satooshi/php-coveralls:~1.0.0 --dev --no-progress --prefer-source" failed and exited with 1 during .

```
in https://travis-ci.org/piwik/component-decompress/jobs/145725130
so i'm disabling coveralls