### PR TITLE
Convert to integer to avoid PHP warning

### DIFF
--- a/libs/PclZip/pclzip.lib.php
+++ b/libs/PclZip/pclzip.lib.php
@@ -1784,9 +1784,9 @@ class PclZip
     }
 
     // ----- Get 'memory_limit' configuration value
-    $v_memory_limit = ini_get('memory_limit');
-    $v_memory_limit = trim($v_memory_limit);
+    $v_memory_limit = trim(ini_get('memory_limit'));
     $last           = strtolower(substr($v_memory_limit, -1));
+    $v_memory_limit = intval($v_memory_limit);
 
     if ($last == 'g') {
       //$v_memory_limit = $v_memory_limit*1024*1024*1024;

--- a/libs/README.md
+++ b/libs/README.md
@@ -6,5 +6,6 @@ third-party libraries:
 
  * PclZip/
    - line 1720, added possibility to define a callable for `PCLZIP_CB_PRE_EXTRACT`. Before one needed to pass a function name
+   - line 1789, convert to integer to avoid warning on PHP 7.1+ (see [#9](https://github.com/piwik/component-decompress/pull/9))
    - line 3676, ignore touch() - utime failed warning
    - line 5401, replaced `php_uname()` by `PHP_OS` (see [#2](https://github.com/piwik/component-decompress/issues/2))


### PR DESCRIPTION
I received the following warning the last two times I updated Piwik (PHP 7.1):

> WARNING: .../public/vendor/piwik/decompress/libs/PclZip/pclzip.lib.php(1797): Notice - A non well formed numeric value encountered

This fix is intended to resolve the problem by converting to integer before the multiplication operation. 
The existing tests trigger the warning and now pass with this change on PHP 7.1.